### PR TITLE
Restrict voice search button to authenticated users

### DIFF
--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -32,6 +32,7 @@
                     @if(request()->routeIs('documents.brs')) aria-current="page" @endif>
                     BRS
                 </a>
+                @auth
                 @if (!auth()->user()->isAdmin())
                 <button type="button"
                     data-voice-search
@@ -44,6 +45,7 @@
                     <span class="text-sound">Voice</span>
                 </button>
                 @endif
+                @endauth
                 @auth
                 @if(auth()->user()->isAdmin())
                 {{-- Progress Notifications untuk Admin --}}
@@ -173,6 +175,7 @@
                 class="block px-3 py-2 text-base font-medium text-gray-700 hover:text-blue-600 hover:bg-white rounded-md hover-sound text-sound {{ request()->routeIs('documents.brs') ? 'text-blue-600 bg-blue-50' : '' }}">
                 <i class="fas fa-newspaper mr-2" aria-hidden="true"></i>BRS
             </a>
+            @auth
             @if (!auth()->user()->isAdmin())
             <button type="button"
                 data-voice-search
@@ -182,6 +185,7 @@
                 <i class="fas fa-microphone mr-2" aria-hidden="true"></i>Voice Search
             </button>
             @endif
+            @endauth
             @auth
             @if(auth()->user()->isAdmin())
             {{-- Admin Mobile Menu --}}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -157,7 +157,9 @@
 
     <!-- Main Content -->
     <main id="main-content" class="min-h-screen pb-32 pt-0" role="main">
+        @auth
         <div class="hidden">Akun ini : <span id="role-user">{{ auth()->user()->role }}</span></div>
+        @endauth 
         @yield('content')
     </main>
 


### PR DESCRIPTION
Voice search button in navigation is now only visible to authenticated users who are not admins. Also wrapped user role display in app layout with @auth to prevent errors for guests.