### PR TITLE
Set slug on document deletion

### DIFF
--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -71,6 +71,7 @@ class Document extends Model
         static::deleting(function (Document $document) {
             if (is_null($document->deleted_at)) {
                 $document->deleted_by = auth()->id();
+                $document->slug = 'deleted-' . $document->uuid;
                 $document->deleted_reason = $document->deleted_reason
                     ?? request()->input('deleted_reason', 'delete by admin');
                 $document->saveQuietly();


### PR DESCRIPTION
When a document is deleted, its slug is now set to 'deleted-' followed by its UUID. This helps distinguish deleted documents and prevents slug conflicts.